### PR TITLE
Add `*.log` to `.gitignore` for `npm` logs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+*.log


### PR DESCRIPTION
Ain't no one want logs in their repo.
