### PR TITLE
Toggle target mouse follow on/off with click.

### DIFF
--- a/src/demo.js
+++ b/src/demo.js
@@ -88,24 +88,34 @@ class FlowTipDemo extends React.Component {
 }
 
 class FlowTipDemoTarget extends React.Component {
-  state = { posX: 0, posY: 0 };
+  state = { posX: 0, posY: 0, active: true };
 
   handleMouseMove(ev) {
+    if (!this.state.active) {
+      return;
+    }
+
     const position = {
       posX: ev.pageX - 10,
-      posY: ev.pageY - 10
+      posY: ev.pageY - 20
     };
 
     this.setState(position);
     this.props.onTargetMove(position);
   }
 
+  handleMouseClick() {
+    this.setState({active: !this.state.active});
+  }
+
   componentDidMount() {
     window.addEventListener("mousemove", this.handleMouseMove.bind(this));
+    window.addEventListener("click", this.handleMouseClick.bind(this));
   }
 
   componentWillUnmount() {
     window.removeEventListener("mousemove", this.handleMouseMove.bind(this));
+    window.removeEventListener("click", this.handleMouseClick.bind(this));
   }
 
   render() {


### PR DESCRIPTION
Sometimes you don't want it following you. Can be handy if you want to debug events or keep the FlowTip™ within the bounds of the parent and go do something else.
