### PR TITLE
Use `window` dimensions instead of `screen` ones.

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -120,8 +120,14 @@ export default (Content, Tail) => {
       if (this.props.clamp) {
         parent.left = Math.max(parent.left, 0);
         parent.top = Math.max(parent.top, 0);
-        parent.height = Math.min(parent.height, screen.height - parent.top);
-        parent.width = Math.min(parent.width, screen.width - parent.left);
+        parent.height = Math.min(
+          parent.height,
+          window.innerHeight - parent.top
+        );
+        parent.width = Math.min(
+          parent.width,
+          window.innerWidth - parent.left
+        );
       }
       parent.width -= scrollerWidth;
       parent.height -= scrollerHeight;


### PR DESCRIPTION
When trying to keep the flyout in the viewport, `screen` does not accurately represent the viewport – it represents the physical screen size. This is doubly true on mobile devices that switch to portrait mode where the `width` and `height` do not change with respect to the orientation change. Because of this, using the `window.inner*` properties make a lot more sense.

This closes #19.

/cc @qiushihe @cristianjd
