### PR TITLE
use parent class  from props

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -86,7 +86,8 @@ export default (Content, Tail) => {
     }
 
     getParentElement() {
-      return getBoundingParent(this.getAnchorElement());
+      const {parentClass} = this.props;
+      return getBoundingParent(this.getAnchorElement(), parentClass);
     }
 
     getAnchorRect() {


### PR DESCRIPTION
Add parentClass property to scope the bounding parent

Please review @izaakschroeder @qiushihe 
