### PR TITLE
Fix incorrect edge detection logic.

### DIFF
--- a/src/flowtip.js
+++ b/src/flowtip.js
@@ -354,12 +354,12 @@ export default class Flowtip extends Component {
 
     // Edge detection - squeeze
     if (
-      (['top', 'bottom'].indexOf !== region) &&
+      (region === 'top' || region === 'bottom') &&
       !regionParameter.top.fits && !regionParameter.bottom.fits
     ) {
       region = this.availableAndFitsIn(['left', 'right'], regionParameter);
     } else if (
-      (['left', 'right'].indexOf !== region) &&
+      (region === 'left' || region === 'right') &&
       !regionParameter.left.fits && !regionParameter.right.fits
     ) {
       region = this.availableAndFitsIn(['top', 'bottom'], regionParameter);

--- a/test/spec/flowtip.spec.js
+++ b/test/spec/flowtip.spec.js
@@ -28,4 +28,29 @@ describe('FlowTip', () => {
     );
     expect(component.text()).to.equal('left');
   });
+
+  it('should edge detect properly', () => {
+    const parent = {left: 0, top: 0, width: 300, height: 300};
+    const anchor = parent;
+    const tail = {width: 50, height: 50};
+    const content = {width: 150, height: 100};
+    const region = 'top';
+    const offset = {left: 0, top: 0};
+    const target = {left: 150, top: 50, width: 50, height: 50};
+    const component = shallow(
+      <FlowTip
+        parent={parent}
+        anchor={anchor}
+        tail={tail}
+        content={content}
+        region={region}
+        offset={offset}
+        target={target}
+        children={({region}) =>
+          <div>{region}</div>
+        }
+      />
+    );
+    expect(component.text()).to.equal('bottom');
+  });
 });


### PR DESCRIPTION
It looks like previously `.indexOf !== region` should have been `.indexOf(region) !== -1`. Since incorrect edge flipping to the point of UI breakage doesn't happen that often this went undetected for quite some time. So the logic is now fixed to do the right thing and does so in a way a little more performant than calling `indexOf` on a two-element constant array.