### PR TITLE
Remove tests for `node@0.12`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ sudo: false
 language: node_js
 matrix:
   include:
-    # Run tests in Node.js 0.12
-    - node_js: '0.12'
-
     # Run tests in Node.js 4.x
     - node_js: '4'
 


### PR DESCRIPTION
Seems to blow up some `eslint` stuff, so seeing as how its on the way out we may as well remove it.