### PR TITLE
Fix incorrect fallback rotation.

### DIFF
--- a/src/flowtip.js
+++ b/src/flowtip.js
@@ -75,7 +75,7 @@ export default class Flowtip extends Component {
   }
 
   availableAndFitsIn([region, ...regions], regionParameter) {
-    if (!regions || regions.length <= 0) {
+    if (!region) {
       return this.props.region;
     }
 
@@ -395,6 +395,7 @@ export default class Flowtip extends Component {
     }
 
     if (rotation) {
+      rotation.push(region);
       region = this.availableAndFitsIn(rotation, regionParameter);
     }
 


### PR DESCRIPTION
Sometimes rotation is desired to achieve a more visually pleasing experience. Unfortunately the ES6 refactor resulting in the last rotation option never being tried and the default fallback being set to the component's region instead of the last attempted region. Both of these have been addressed and help flowtip respond more elegantly in constrained viewports.

I think the overall code here probably could do with a bit of a refactor (particularly hashing out all the logical passes), but this serves to fix the given issues.