### PR TITLE
Fix param typo in README

### DIFF
--- a/packages/flowtip-react-dom/README.md
+++ b/packages/flowtip-react-dom/README.md
@@ -325,7 +325,7 @@ This results in apparently unnecessary reposition events. When `sticky` is true,
 
 The desired margin between the positioned content tail and the target.
 
-### `targetOffset`: number
+### `edgeOffset`: number
 
 *optional*, *default: `0`*
 


### PR DESCRIPTION
This confused me for some time!