### PR TITLE
Activate flow lint for stricter type annotations

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -3,6 +3,9 @@
 
 [include]
 
+[lints]
+all=error
+
 [libs]
 <PROJECT_ROOT>/flow-typed
 

--- a/packages/flowtip-core/src/flowtip.js
+++ b/packages/flowtip-core/src/flowtip.js
@@ -190,7 +190,7 @@ function constrainTop(config: _Config, region: Region, rect: Rect): number {
  * @param   {string} region A region (`top`, `right`, `bottom`, or `left`).
  * @returns {bool} True if the content will be constrained.
  */
-function getRegionClip(config: _Config, region: Region): Regions {
+function getRegionClip(config: _Config, region: Region): _Regions {
   const {bounds} = config;
   const rect = getRect(config, region);
 
@@ -794,16 +794,27 @@ function normalizeAlign(align: ?Align): number {
   return 0.5;
 }
 
-const defaults = (rawConfig: Config): _Config => (({
-  offset: 0,
-  overlap: 0,
-  ...rawConfig,
-  align: normalizeAlign(rawConfig.align),
-  bounds: Rect.from(rawConfig.bounds),
-  target: Rect.from(rawConfig.target),
-  disabled: {...noRegions, ...rawConfig.disabled},
-  constrain: {...allRegions, ...rawConfig.constrain},
-}: any): _Config);
+const defaults = ({
+  offset = 0,
+  overlap = 0,
+  align,
+  region,
+  bounds,
+  target,
+  content,
+  disabled,
+  constrain,
+}: Config = {}): _Config => ({
+  offset,
+  overlap,
+  align: normalizeAlign(align),
+  region,
+  bounds: Rect.from(bounds),
+  target: Rect.from(target),
+  content,
+  disabled: {...noRegions, ...disabled},
+  constrain: {...allRegions, ...constrain},
+});
 
 /**
  * Calculate a Flowtip layout result.

--- a/packages/flowtip-react-dom/src/FlowTip.js
+++ b/packages/flowtip-react-dom/src/FlowTip.js
@@ -37,6 +37,8 @@ export type State = {
   result: Result | null,
 };
 
+type Style = {[string]: string | number};
+
 export type Props = {
   /** DOMRect (or similar shaped object) of target position. */
   target: RectLike | null,
@@ -76,12 +78,12 @@ export type Props = {
   /** Constrain the content at the bottom boundary. */
   constrainLeft: boolean,
   content: React.ComponentType<{
-    style: Object,
+    style: Style,
     result: Result,
     children?: React.Node,
   }> | string,
   tail?: React.ComponentType<{
-    style: Object,
+    style: Style,
     result: Result,
     children?: React.Node,
   }>,
@@ -314,7 +316,10 @@ class FlowTip extends React.Component<Props, State> {
 
     let result = null;
 
-    if (bounds && target && content && (!nextProps.Tail || tail)) {
+    if (
+      bounds && target && content &&
+      (typeof nextProps.Tail !== 'function' || tail)
+    ) {
       const config = {
         offset: this._getOffset(nextProps),
         overlap: this._getOverlap(nextProps),
@@ -504,12 +509,12 @@ class FlowTip extends React.Component<Props, State> {
    * @param   {Object} result - A `flowtip` layout result.
    * @returns {Object} Content position style.
    */
-  _getContentStyle(result: Result): Object {
+  _getContentStyle(result: Result): Style {
     const {containingBlock} = this.state;
 
     // Hide the result with css clip - preserving its ability to be measured -
     // when working with a static layout result mock.
-    if (!result || result._static) {
+    if (!result || result._static === true) {
       return {
         position: 'absolute',
         clip: 'rect(0 0 0 0)',
@@ -530,7 +535,7 @@ class FlowTip extends React.Component<Props, State> {
    * @param   {Object} result - A `flowtip` layout result.
    * @returns {Object} Tail position style.
    */
-  _getTailStyle(result: Result): Object {
+  _getTailStyle(result: Result): Style {
     const {tailOffset} = this.props;
     const {tail} = this.state;
 
@@ -540,7 +545,7 @@ class FlowTip extends React.Component<Props, State> {
 
     const tailAttached = result.offset >= this._getOffset(this.props);
 
-    const style: Object = {
+    const style: Style = {
       position: 'absolute',
       visibility: tailAttached ? 'visible' : 'hidden',
     };


### PR DESCRIPTION
Enabling flow lint enforces better and more accurate flow type annotations.

With `all=error`, any reference to `any`, `Function`, or `Object` is now a flow error (unless the rule is disabled inline). See https://flow.org/en/docs/linting/ for documentation.