### PR TITLE
Support React 16

### DIFF
--- a/packages/flowtip-react-dom/package-lock.json
+++ b/packages/flowtip-react-dom/package-lock.json
@@ -1,663 +1,760 @@
 {
-	"requires": true,
-	"lockfileVersion": 1,
-	"dependencies": {
-		"@types/react": {
-			"version": "15.6.1",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-15.6.1.tgz",
-			"integrity": "sha512-tfKYi5NyVcZH8zkF9JTbPpTcebanZpkxEYXQUlpeqg4kV8gC3LeM4acPD4y53Yx0etWChURVx+Rj9aoxTcyBkA=="
-		},
-		"asap": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-		},
-		"boolbase": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
-		},
-		"cheerio": {
-			"version": "0.22.0",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
-			"integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
-			"requires": {
-				"css-select": "1.2.0",
-				"dom-serializer": "0.1.0",
-				"entities": "1.1.1",
-				"htmlparser2": "3.9.2",
-				"lodash.assignin": "4.2.0",
-				"lodash.bind": "4.2.1",
-				"lodash.defaults": "4.2.0",
-				"lodash.filter": "4.6.0",
-				"lodash.flatten": "4.4.0",
-				"lodash.foreach": "4.5.0",
-				"lodash.map": "4.6.0",
-				"lodash.merge": "4.6.0",
-				"lodash.pick": "4.4.0",
-				"lodash.reduce": "4.6.0",
-				"lodash.reject": "4.6.0",
-				"lodash.some": "4.6.0"
-			}
-		},
-		"core-js": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-		},
-		"core-util-is": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-		},
-		"create-react-class": {
-			"version": "15.6.0",
-			"resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
-			"integrity": "sha1-q0SEl8JlZuHilBPogyB9V8/nvtQ=",
-			"requires": {
-				"fbjs": "0.8.14",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1"
-			}
-		},
-		"css-select": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-			"requires": {
-				"boolbase": "1.0.0",
-				"css-what": "2.1.0",
-				"domutils": "1.5.1",
-				"nth-check": "1.0.1"
-			}
-		},
-		"css-what": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-			"integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
-		},
-		"deep-equal-ident": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/deep-equal-ident/-/deep-equal-ident-1.1.1.tgz",
-			"integrity": "sha1-BvS4nlNxDNbOpKd4HHqVZkLejck=",
-			"requires": {
-				"lodash.isequal": "3.0.4"
-			}
-		},
-		"define-properties": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-			"requires": {
-				"foreach": "2.0.5",
-				"object-keys": "1.0.11"
-			}
-		},
-		"dom-serializer": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
-			"requires": {
-				"domelementtype": "1.1.3",
-				"entities": "1.1.1"
-			},
-			"dependencies": {
-				"domelementtype": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
-				}
-			}
-		},
-		"domelementtype": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-			"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
-		},
-		"domhandler": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
-			"integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
-			"requires": {
-				"domelementtype": "1.3.0"
-			}
-		},
-		"domutils": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-			"requires": {
-				"dom-serializer": "0.1.0",
-				"domelementtype": "1.3.0"
-			}
-		},
-		"encoding": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-			"requires": {
-				"iconv-lite": "0.4.18"
-			}
-		},
-		"entities": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-			"integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
-		},
-		"enzyme": {
-			"version": "2.9.1",
-			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-2.9.1.tgz",
-			"integrity": "sha1-B9XOaRJBJA+4F78sSxjW5TAkDfY=",
-			"requires": {
-				"cheerio": "0.22.0",
-				"function.prototype.name": "1.0.3",
-				"is-subset": "0.1.1",
-				"lodash": "4.17.4",
-				"object-is": "1.0.1",
-				"object.assign": "4.0.4",
-				"object.entries": "1.0.4",
-				"object.values": "1.0.4",
-				"prop-types": "15.5.10",
-				"uuid": "3.1.0"
-			}
-		},
-		"enzyme-matchers": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/enzyme-matchers/-/enzyme-matchers-3.7.0.tgz",
-			"integrity": "sha1-O2g75/GrNCniG0f36X1PsG2pJmI=",
-			"requires": {
-				"deep-equal-ident": "1.1.1"
-			}
-		},
-		"enzyme-to-json": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-1.5.1.tgz",
-			"integrity": "sha1-409NEmuz9Gls44ALUfntg99wh5k=",
-			"requires": {
-				"lodash.filter": "4.6.0",
-				"lodash.isnil": "4.0.0",
-				"lodash.isplainobject": "4.0.6",
-				"lodash.omitby": "4.6.0",
-				"lodash.range": "3.2.0",
-				"object-values": "1.0.0",
-				"object.entries": "1.0.4"
-			}
-		},
-		"es-abstract": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.0.tgz",
-			"integrity": "sha512-Cf9/h5MrXtExM20gSS55YFrGKCyPrRBjIVBtVyy8vmlsDfe0NPKMWj65tPLgzyfPuapWxh5whpXCtW4+AW5mRg==",
-			"requires": {
-				"es-to-primitive": "1.1.1",
-				"function-bind": "1.1.0",
-				"has": "1.0.1",
-				"is-callable": "1.1.3",
-				"is-regex": "1.0.4"
-			}
-		},
-		"es-to-primitive": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-			"requires": {
-				"is-callable": "1.1.3",
-				"is-date-object": "1.0.1",
-				"is-symbol": "1.0.1"
-			}
-		},
-		"fbjs": {
-			"version": "0.8.14",
-			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.14.tgz",
-			"integrity": "sha1-0dviviVMNakeCfMfnNUKQLKg7Rw=",
-			"requires": {
-				"core-js": "1.2.7",
-				"isomorphic-fetch": "2.2.1",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"promise": "7.3.1",
-				"setimmediate": "1.0.5",
-				"ua-parser-js": "0.7.14"
-			}
-		},
-		"foreach": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-		},
-		"function-bind": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-			"integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E="
-		},
-		"function.prototype.name": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.0.3.tgz",
-			"integrity": "sha512-5EblxZUdioXi2JiMZ9FUbwYj40eQ9MFHyzFLBSPdlRl3SO8l7SLWuAnQ/at/1Wi4hjJwME/C5WpF2ZfAc8nGNw==",
-			"requires": {
-				"define-properties": "1.1.2",
-				"function-bind": "1.1.0",
-				"is-callable": "1.1.3"
-			}
-		},
-		"has": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-			"requires": {
-				"function-bind": "1.1.0"
-			}
-		},
-		"htmlparser2": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
-			"integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
-			"requires": {
-				"domelementtype": "1.3.0",
-				"domhandler": "2.4.1",
-				"domutils": "1.5.1",
-				"entities": "1.1.1",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
-			}
-		},
-		"iconv-lite": {
-			"version": "0.4.18",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-			"integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA=="
-		},
-		"inherits": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-		},
-		"is-callable": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
-		},
-		"is-date-object": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
-		},
-		"is-regex": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-			"requires": {
-				"has": "1.0.1"
-			}
-		},
-		"is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-		},
-		"is-subset": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY="
-		},
-		"is-symbol": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
-		},
-		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-		},
-		"isomorphic-fetch": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-			"requires": {
-				"node-fetch": "1.7.2",
-				"whatwg-fetch": "2.0.3"
-			}
-		},
-		"jest-enzyme": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/jest-enzyme/-/jest-enzyme-3.7.0.tgz",
-			"integrity": "sha1-SabRY1C2Z3UMv0yIHvMFaqhdCJg=",
-			"requires": {
-				"@types/react": "15.6.1",
-				"enzyme-matchers": "3.7.0",
-				"enzyme-to-json": "1.5.1"
-			}
-		},
-		"js-tokens": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-		},
-		"lodash": {
-			"version": "4.17.4",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-		},
-		"lodash._baseisequal": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
-			"integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
-			"requires": {
-				"lodash.isarray": "3.0.4",
-				"lodash.istypedarray": "3.0.6",
-				"lodash.keys": "3.1.2"
-			}
-		},
-		"lodash._bindcallback": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-			"integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
-		},
-		"lodash._getnative": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-		},
-		"lodash.assignin": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
-			"integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
-		},
-		"lodash.bind": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
-			"integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
-		},
-		"lodash.defaults": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-			"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
-		},
-		"lodash.filter": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
-			"integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
-		},
-		"lodash.flatten": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
-		},
-		"lodash.foreach": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
-			"integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
-		},
-		"lodash.isarguments": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-		},
-		"lodash.isarray": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-		},
-		"lodash.isequal": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-3.0.4.tgz",
-			"integrity": "sha1-HDXrO27wzR/1F0Pj6jz3/f/ay2Q=",
-			"requires": {
-				"lodash._baseisequal": "3.0.7",
-				"lodash._bindcallback": "3.0.1"
-			}
-		},
-		"lodash.isnil": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
-			"integrity": "sha1-SeKM1VkBNFjIFMVHnTxmOiG/qmw="
-		},
-		"lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-		},
-		"lodash.istypedarray": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
-			"integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I="
-		},
-		"lodash.keys": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-			"requires": {
-				"lodash._getnative": "3.9.1",
-				"lodash.isarguments": "3.1.0",
-				"lodash.isarray": "3.0.4"
-			}
-		},
-		"lodash.map": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-			"integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
-		},
-		"lodash.merge": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
-			"integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
-		},
-		"lodash.omitby": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/lodash.omitby/-/lodash.omitby-4.6.0.tgz",
-			"integrity": "sha1-XBX/R1StVVAWtTwEExHo8HkgR5E="
-		},
-		"lodash.pick": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-			"integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
-		},
-		"lodash.range": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.range/-/lodash.range-3.2.0.tgz",
-			"integrity": "sha1-9GHliPZmg/fq3q3lE+OKaaVloV0="
-		},
-		"lodash.reduce": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
-			"integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
-		},
-		"lodash.reject": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
-			"integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU="
-		},
-		"lodash.some": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
-			"integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
-		},
-		"loose-envify": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-			"requires": {
-				"js-tokens": "3.0.2"
-			}
-		},
-		"node-fetch": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.2.tgz",
-			"integrity": "sha512-xZZUq2yDhKMIn/UgG5q//IZSNLJIwW2QxS14CNH5spuiXkITM2pUitjdq58yLSaU7m4M0wBNaM2Gh/ggY4YJig==",
-			"requires": {
-				"encoding": "0.1.12",
-				"is-stream": "1.1.0"
-			}
-		},
-		"nth-check": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
-			"integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
-			"requires": {
-				"boolbase": "1.0.0"
-			}
-		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-		},
-		"object-is": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-			"integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
-		},
-		"object-keys": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
-		},
-		"object-values": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/object-values/-/object-values-1.0.0.tgz",
-			"integrity": "sha1-cq+DljARnluYw7AruMJ+MjcVgQU="
-		},
-		"object.assign": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
-			"integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
-			"requires": {
-				"define-properties": "1.1.2",
-				"function-bind": "1.1.0",
-				"object-keys": "1.0.11"
-			}
-		},
-		"object.entries": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
-			"integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
-			"requires": {
-				"define-properties": "1.1.2",
-				"es-abstract": "1.8.0",
-				"function-bind": "1.1.0",
-				"has": "1.0.1"
-			}
-		},
-		"object.values": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
-			"integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
-			"requires": {
-				"define-properties": "1.1.2",
-				"es-abstract": "1.8.0",
-				"function-bind": "1.1.0",
-				"has": "1.0.1"
-			}
-		},
-		"process-nextick-args": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-		},
-		"promise": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-			"requires": {
-				"asap": "2.0.6"
-			}
-		},
-		"prop-types": {
-			"version": "15.5.10",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
-			"integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
-			"requires": {
-				"fbjs": "0.8.14",
-				"loose-envify": "1.3.1"
-			}
-		},
-		"react": {
-			"version": "15.6.1",
-			"resolved": "https://registry.npmjs.org/react/-/react-15.6.1.tgz",
-			"integrity": "sha1-uqhDTsZ4C96ZfNw4C3nNM7ljk98=",
-			"requires": {
-				"create-react-class": "15.6.0",
-				"fbjs": "0.8.14",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"prop-types": "15.5.10"
-			}
-		},
-		"react-dom": {
-			"version": "15.6.1",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.1.tgz",
-			"integrity": "sha1-LLDtQZEDjlPCCes6eaI+Kkz5lHA=",
-			"requires": {
-				"fbjs": "0.8.14",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"prop-types": "15.5.10"
-			}
-		},
-		"react-resize-observer": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/react-resize-observer/-/react-resize-observer-0.2.0.tgz",
-			"integrity": "sha512-vSy27PZr5ExURrXEKWgdRgfXjp7l0MnNCEiUlp/FMOmvtzuB/aGNU8LlfmfAmhjU0E8N4ZtSo3TJ8krGIi+l4Q=="
-		},
-		"react-test-renderer": {
-			"version": "15.6.1",
-			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-15.6.1.tgz",
-			"integrity": "sha1-Am9KW7VVJmH9LMS7zQ1LyKNev34=",
-			"requires": {
-				"fbjs": "0.8.14",
-				"object-assign": "4.1.1"
-			}
-		},
-		"readable-stream": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "1.0.7",
-				"safe-buffer": "5.1.1",
-				"string_decoder": "1.0.3",
-				"util-deprecate": "1.0.2"
-			}
-		},
-		"safe-buffer": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-		},
-		"setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-		},
-		"string_decoder": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-			"requires": {
-				"safe-buffer": "5.1.1"
-			}
-		},
-		"ua-parser-js": {
-			"version": "0.7.14",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz",
-			"integrity": "sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o="
-		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-		},
-		"uuid": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
-		},
-		"whatwg-fetch": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
-		}
-	}
+  "name": "flowtip-react-dom",
+  "version": "5.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/react": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-15.6.1.tgz",
+      "integrity": "sha512-tfKYi5NyVcZH8zkF9JTbPpTcebanZpkxEYXQUlpeqg4kV8gC3LeM4acPD4y53Yx0etWChURVx+Rj9aoxTcyBkA==",
+      "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+      "dev": true
+    },
+    "cheerio": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+      "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+      "dev": true,
+      "requires": {
+        "css-select": "1.2.0",
+        "dom-serializer": "0.1.0",
+        "entities": "1.1.1",
+        "htmlparser2": "3.9.2",
+        "lodash.assignin": "4.2.0",
+        "lodash.bind": "4.2.1",
+        "lodash.defaults": "4.2.0",
+        "lodash.filter": "4.6.0",
+        "lodash.flatten": "4.4.0",
+        "lodash.foreach": "4.5.0",
+        "lodash.map": "4.6.0",
+        "lodash.merge": "4.6.0",
+        "lodash.pick": "4.4.0",
+        "lodash.reduce": "4.6.0",
+        "lodash.reject": "4.6.0",
+        "lodash.some": "4.6.0"
+      }
+    },
+    "core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "create-react-class": {
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
+      "integrity": "sha1-q0SEl8JlZuHilBPogyB9V8/nvtQ=",
+      "dev": true,
+      "requires": {
+        "fbjs": "0.8.14",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      }
+    },
+    "css-select": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+      "dev": true,
+      "requires": {
+        "boolbase": "1.0.0",
+        "css-what": "2.1.0",
+        "domutils": "1.5.1",
+        "nth-check": "1.0.1"
+      }
+    },
+    "css-what": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
+      "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
+      "dev": true
+    },
+    "deep-equal-ident": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal-ident/-/deep-equal-ident-1.1.1.tgz",
+      "integrity": "sha1-BvS4nlNxDNbOpKd4HHqVZkLejck=",
+      "dev": true,
+      "requires": {
+        "lodash.isequal": "3.0.4"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
+      "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
+      }
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.18"
+      }
+    },
+    "entities": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+      "dev": true
+    },
+    "enzyme": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-2.9.1.tgz",
+      "integrity": "sha1-B9XOaRJBJA+4F78sSxjW5TAkDfY=",
+      "dev": true,
+      "requires": {
+        "cheerio": "0.22.0",
+        "function.prototype.name": "1.0.3",
+        "is-subset": "0.1.1",
+        "lodash": "4.17.4",
+        "object-is": "1.0.1",
+        "object.assign": "4.0.4",
+        "object.entries": "1.0.4",
+        "object.values": "1.0.4",
+        "prop-types": "15.5.10",
+        "uuid": "3.1.0"
+      }
+    },
+    "enzyme-matchers": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/enzyme-matchers/-/enzyme-matchers-3.7.0.tgz",
+      "integrity": "sha1-O2g75/GrNCniG0f36X1PsG2pJmI=",
+      "dev": true,
+      "requires": {
+        "deep-equal-ident": "1.1.1"
+      }
+    },
+    "enzyme-to-json": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-1.5.1.tgz",
+      "integrity": "sha1-409NEmuz9Gls44ALUfntg99wh5k=",
+      "dev": true,
+      "requires": {
+        "lodash.filter": "4.6.0",
+        "lodash.isnil": "4.0.0",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.omitby": "4.6.0",
+        "lodash.range": "3.2.0",
+        "object-values": "1.0.0",
+        "object.entries": "1.0.4"
+      }
+    },
+    "es-abstract": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.0.tgz",
+      "integrity": "sha512-Cf9/h5MrXtExM20gSS55YFrGKCyPrRBjIVBtVyy8vmlsDfe0NPKMWj65tPLgzyfPuapWxh5whpXCtW4+AW5mRg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.0",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
+    },
+    "fbjs": {
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.14.tgz",
+      "integrity": "sha1-0dviviVMNakeCfMfnNUKQLKg7Rw=",
+      "dev": true,
+      "requires": {
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.14"
+      }
+    },
+    "flowtip-core": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/flowtip-core/-/flowtip-core-5.0.0.tgz",
+      "integrity": "sha512-IErkKLJilTAcEBAFq4qN2NTrssKXqKRiw3NkXQtRb3VTVm9zIAKB/eJ8lCd7cRuRXwUHLr4yjnX50cgkl/YPAQ=="
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "dev": true
+    },
+    "function.prototype.name": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.0.3.tgz",
+      "integrity": "sha512-5EblxZUdioXi2JiMZ9FUbwYj40eQ9MFHyzFLBSPdlRl3SO8l7SLWuAnQ/at/1Wi4hjJwME/C5WpF2ZfAc8nGNw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.0",
+        "is-callable": "1.1.3"
+      }
+    },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.0"
+      }
+    },
+    "htmlparser2": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+      "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0",
+        "domhandler": "2.4.1",
+        "domutils": "1.5.1",
+        "entities": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
+      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "requires": {
+        "node-fetch": "1.7.2",
+        "whatwg-fetch": "2.0.3"
+      }
+    },
+    "jest-enzyme": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/jest-enzyme/-/jest-enzyme-3.7.0.tgz",
+      "integrity": "sha1-SabRY1C2Z3UMv0yIHvMFaqhdCJg=",
+      "dev": true,
+      "requires": {
+        "@types/react": "15.6.1",
+        "enzyme-matchers": "3.7.0",
+        "enzyme-to-json": "1.5.1"
+      }
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
+    },
+    "lodash._baseisequal": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
+      "integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
+      "dev": true,
+      "requires": {
+        "lodash.isarray": "3.0.4",
+        "lodash.istypedarray": "3.0.6",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._bindcallback": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash.assignin": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+      "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI=",
+      "dev": true
+    },
+    "lodash.bind": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+      "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=",
+      "dev": true
+    },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+      "dev": true
+    },
+    "lodash.filter": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4=",
+      "dev": true
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+      "dev": true
+    },
+    "lodash.foreach": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
+      "dev": true
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-3.0.4.tgz",
+      "integrity": "sha1-HDXrO27wzR/1F0Pj6jz3/f/ay2Q=",
+      "dev": true,
+      "requires": {
+        "lodash._baseisequal": "3.0.7",
+        "lodash._bindcallback": "3.0.1"
+      }
+    },
+    "lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha1-SeKM1VkBNFjIFMVHnTxmOiG/qmw=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
+    "lodash.istypedarray": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+      "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash.map": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU=",
+      "dev": true
+    },
+    "lodash.omitby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.omitby/-/lodash.omitby-4.6.0.tgz",
+      "integrity": "sha1-XBX/R1StVVAWtTwEExHo8HkgR5E=",
+      "dev": true
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+      "dev": true
+    },
+    "lodash.range": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.range/-/lodash.range-3.2.0.tgz",
+      "integrity": "sha1-9GHliPZmg/fq3q3lE+OKaaVloV0=",
+      "dev": true
+    },
+    "lodash.reduce": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs=",
+      "dev": true
+    },
+    "lodash.reject": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+      "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU=",
+      "dev": true
+    },
+    "lodash.some": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true,
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.2.tgz",
+      "integrity": "sha512-xZZUq2yDhKMIn/UgG5q//IZSNLJIwW2QxS14CNH5spuiXkITM2pUitjdq58yLSaU7m4M0wBNaM2Gh/ggY4YJig==",
+      "dev": true,
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
+    },
+    "nth-check": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
+      "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+      "dev": true,
+      "requires": {
+        "boolbase": "1.0.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object-is": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
+      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
+    },
+    "object-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/object-values/-/object-values-1.0.0.tgz",
+      "integrity": "sha1-cq+DljARnluYw7AruMJ+MjcVgQU=",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
+      "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.0",
+        "object-keys": "1.0.11"
+      }
+    },
+    "object.entries": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
+      "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.8.0",
+        "function-bind": "1.1.0",
+        "has": "1.0.1"
+      }
+    },
+    "object.values": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
+      "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.8.0",
+        "function-bind": "1.1.0",
+        "has": "1.0.1"
+      }
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
+      "requires": {
+        "asap": "2.0.6"
+      }
+    },
+    "prop-types": {
+      "version": "15.5.10",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
+      "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
+      "dev": true,
+      "requires": {
+        "fbjs": "0.8.14",
+        "loose-envify": "1.3.1"
+      }
+    },
+    "react": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-15.6.1.tgz",
+      "integrity": "sha1-uqhDTsZ4C96ZfNw4C3nNM7ljk98=",
+      "dev": true,
+      "requires": {
+        "create-react-class": "15.6.0",
+        "fbjs": "0.8.14",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.5.10"
+      }
+    },
+    "react-dom": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.1.tgz",
+      "integrity": "sha1-LLDtQZEDjlPCCes6eaI+Kkz5lHA=",
+      "dev": true,
+      "requires": {
+        "fbjs": "0.8.14",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.5.10"
+      }
+    },
+    "react-resize-observer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/react-resize-observer/-/react-resize-observer-0.2.1.tgz",
+      "integrity": "sha512-yELGgPrJT0P6IeBkTW3jbCtz/slsRqBJsd4vzP647XZMUtpafeBJRchrlrZf2hEKo+YNQvrr6+P7jmd4XRibQg=="
+    },
+    "react-test-renderer": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-15.6.1.tgz",
+      "integrity": "sha1-Am9KW7VVJmH9LMS7zQ1LyKNev34=",
+      "dev": true,
+      "requires": {
+        "fbjs": "0.8.14",
+        "object-assign": "4.1.1"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "ua-parser-js": {
+      "version": "0.7.14",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz",
+      "integrity": "sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o=",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+      "dev": true
+    },
+    "whatwg-fetch": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=",
+      "dev": true
+    }
+  }
 }

--- a/packages/flowtip-react-dom/package.json
+++ b/packages/flowtip-react-dom/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "flowtip-core": "^5.0.0",
-    "react-resize-observer": "^0.2.0"
+    "react-resize-observer": "^0.2.1"
   },
   "devDependencies": {
     "enzyme": "^2.9.1",

--- a/packages/flowtip-react-dom/src/FlowTip.js
+++ b/packages/flowtip-react-dom/src/FlowTip.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react';
-import {findDOMNode} from 'react-dom';
 import ResizeObserver from 'react-resize-observer';
 
 import flowtip, {
@@ -15,6 +14,7 @@ import flowtip, {
 import type {RectLike, Region, Align, Dimensions, Result} from 'flowtip-core';
 
 import getContainingBlock from './util/getContainingBlock';
+import findDOMNode from './util/findDOMNode';
 
 // Static `flowtip` layout calculation result mock for use during initial client
 // side render or on server render where DOM feedback is not possible.

--- a/packages/flowtip-react-dom/src/util/findDOMNode.js
+++ b/packages/flowtip-react-dom/src/util/findDOMNode.js
@@ -1,0 +1,23 @@
+// @flow
+
+import {findDOMNode as _findDOMNode} from 'react-dom';
+import type {Component} from 'react';
+
+// flowlint unclear-type: off
+const findDOMNode = (
+  componentOrElement: Element | ?Component<any, any>,
+): null | Element | Text => {
+  const node = _findDOMNode(componentOrElement);
+  if (node) return node;
+
+  let fiberNode =
+    componentOrElement && (componentOrElement: any)._reactInternalFiber;
+
+  while (fiberNode && !(fiberNode.stateNode instanceof Element)) {
+    fiberNode = fiberNode.child;
+  }
+
+  return fiberNode ? fiberNode.stateNode : null;
+};
+
+export default findDOMNode;


### PR DESCRIPTION
`findDOMNode` is slated for deprecation soon, and support in React 16 appears to be partially dropped already.

For us to transition completely away from it, we would need to pass a ref prop down to the provided `content` component, including it as part of the `FlowTip` api. This is less ideal than automatically resolving the correct ref as `findDOMNode` currently does and would make the lib more complicated to use. (See: #55)

Until `findDOMNode` support is dropped completely, or we decide on a clean mechanism for passing the ref around, we rely on a custom `findDOMNode` function that will safely attempt to detect the rendered node using react fiber internals when necessary. This universally supports React 16 and earlier versions.

See:
- https://github.com/yannickcr/eslint-plugin-react/issues/678
- https://github.com/reactjs/reactjs.org/issues/201
- https://stackoverflow.com/questions/48062095/update-to-react-16-finddomnode-stops-working#answer-48273014