### PR TITLE
Fix inconspicuous bug in flowtip layout resolver

### DIFF
--- a/packages/flowtip-core/src/flowtip.js
+++ b/packages/flowtip-core/src/flowtip.js
@@ -207,7 +207,7 @@ function getRegionClip(config: _Config, region: Region): _Regions {
     top: rect.top + topOffset < bounds.top,
     right: bounds.right < rect.right + rightOffset,
     bottom: bounds.bottom < rect.bottom + bottomOffset,
-    left: rect.left + leftOffset < bounds.top,
+    left: rect.left + leftOffset < bounds.left,
   };
 }
 


### PR DESCRIPTION
This hasn't yet manifested as a noticeable issue since 99% of the time `bounds.left` and `bounds.top` are both `0`. An issue would only surface here in scenarios where the provided bounds are drastically different from the viewport.