### PR TITLE
Include edgeOffset in layout calculation

### DIFF
--- a/packages/flowtip-react-dom/src/FlowTip.js
+++ b/packages/flowtip-react-dom/src/FlowTip.js
@@ -331,6 +331,7 @@ class FlowTip extends React.Component<Props, State> {
     ) {
       const config = {
         offset: this._getOffset(nextProps),
+        edgeOffset: nextProps.edgeOffset,
         overlap: this._getOverlap(nextProps),
         align: nextProps.align,
         region: this._getRegion(nextProps),
@@ -414,10 +415,7 @@ class FlowTip extends React.Component<Props, State> {
     const viewportRect = new Rect(0, 0, window.innerWidth, window.innerHeight);
 
     const processBounds = (boundsRect: RectLike) => {
-      const visibleBounds = Rect.grow(
-        Rect.intersect(viewportRect, boundsRect),
-        -nextProps.edgeOffset,
-      );
+      const visibleBounds = Rect.intersect(viewportRect, boundsRect);
 
       // A rect with negative dimensions doesn't make sense here.
       // Returning null will disable rendering content.


### PR DESCRIPTION
`edgeOffset` is used to represent a margin at the the bounds rect edge. Previously it was only a prop used within the `FlowTip` react component that was subtracted from the resolved `bounds` rect, effectively shrinking it. This had the undesirable effect of also applying the margin to between the positioned tooltip and viewport edge when the target was outside the viewport.

What we really want the tail side of the tooltip to have its own margin, separate from the body. When the tooltip is positioned at the screen edge, the larger of the two margins will determine the final position.

### Before:
At the boundary edge, `offset` and `targetOffset` are be added together.
![image](https://user-images.githubusercontent.com/1074748/37636987-9c6941ea-2bc2-11e8-8da3-dc755818efe7.png)


### After:
At the boundary edge, only largest of `offset` and `targetOffset` is used.
![image](https://user-images.githubusercontent.com/1074748/37636994-a2c7d2ae-2bc2-11e8-8693-61a2cd7f3036.png)

