### PR TITLE
Fix position jank when constrained to viewport edge

### DIFF
--- a/packages/flowtip-react-dom/src/FlowTip.js
+++ b/packages/flowtip-react-dom/src/FlowTip.js
@@ -11,6 +11,7 @@ import {
   getContainingBlock,
   getClippingBlock,
   getContentRect,
+  getViewportRect,
 } from './util/dom';
 import {getRegion, getOverlap, getOffset} from './util/state';
 import defaultRender from './defaultRender';
@@ -61,6 +62,7 @@ class FlowTip extends React.Component<Props, State> {
   _node: HTMLElement | null = null;
   state = {
     containingBlock: Rect.zero,
+    boundedByViewport: true,
     bounds: null,
     content: null,
     contentBorders: null,
@@ -177,8 +179,12 @@ class FlowTip extends React.Component<Props, State> {
 
     const contentBorders = this._node ? getBorders(this._node) : null;
 
+    const boundedByViewport =
+      !nextProps.bounds && this._clippingBlockNode === document.documentElement;
+
     return {
       containingBlock,
+      boundedByViewport,
       bounds,
       content,
       contentBorders,
@@ -230,10 +236,8 @@ class FlowTip extends React.Component<Props, State> {
   // DOM Measurement Methods ===================================================
 
   _getBoundsRect(nextProps: Props): Rect | null {
-    const viewportRect = new Rect(0, 0, window.innerWidth, window.innerHeight);
-
     const processBounds = (boundsRect: RectLike) => {
-      const visibleBounds = Rect.intersect(viewportRect, boundsRect);
+      const visibleBounds = Rect.intersect(getViewportRect(), boundsRect);
 
       return Rect.isValid(visibleBounds) ? visibleBounds : null;
     };

--- a/packages/flowtip-react-dom/src/util/dom.js
+++ b/packages/flowtip-react-dom/src/util/dom.js
@@ -72,3 +72,7 @@ export function getContentRect(node: HTMLElement): Rect {
     Math.min(rect.height - border.top - border.bottom, node.clientHeight) || 0,
   );
 }
+
+export function getViewportRect(): Rect {
+  return new Rect(0, 0, window.innerWidth, window.innerHeight);
+}

--- a/packages/flowtip-react-dom/src/util/render.js
+++ b/packages/flowtip-react-dom/src/util/render.js
@@ -1,9 +1,10 @@
 // @flow
 
-import {getClampedTailPosition, RIGHT, LEFT} from 'flowtip-core';
+import {Rect, getClampedTailPosition, RIGHT, LEFT} from 'flowtip-core';
 
 import type {Style, Props, State} from '../types';
 import {getOffset} from '../util/state';
+import {getViewportRect} from '../util/dom';
 
 /**
  * Get the content element position style based on the current layout result
@@ -21,6 +22,43 @@ export const getContentStyle = (props: Props, state: State) => {
       position: 'absolute',
       clip: 'rect(0 0 0 0)',
     };
+  }
+
+  if (
+    Rect.areEqual(state.result.bounds, getViewportRect()) &&
+    !Rect.isValid(Rect.intersect(state.result.bounds, state.result.target))
+  ) {
+    if (props.constrainTop && state.result.region === 'bottom') {
+      return {
+        position: 'fixed',
+        top: Math.round(state.result.rect.top),
+        left: Math.round(state.result.rect.left),
+      };
+    }
+
+    if (props.constrainRight && state.result.region === 'left') {
+      return {
+        position: 'fixed',
+        top: Math.round(state.result.rect.top),
+        right: Math.round(window.innerWidth - state.result.rect.right),
+      };
+    }
+
+    if (props.constrainBottom && state.result.region === 'top') {
+      return {
+        position: 'fixed',
+        bottom: Math.round(window.innerHeight - state.result.rect.bottom),
+        left: Math.round(state.result.rect.left),
+      };
+    }
+
+    if (props.constrainLeft && state.result.region === 'right') {
+      return {
+        position: 'fixed',
+        top: Math.round(state.result.rect.top),
+        left: Math.round(state.result.rect.left),
+      };
+    }
   }
 
   return {


### PR DESCRIPTION
(Depends on : #62)
Closes: #43 

When the target is scrolled outside of the viewport and the tooltip is constrained to the edge of the window, Chrome's behavior of apparently debouncing window scroll events causes the tooltip position to shift around slightly as the user scrolls. This is a consequence of the absolute positioned tooltip being transformed to appear to be fixed to the viewport edge.

To fix this, we detect scenarios where the tooltip is constrained at the viewport edge and the bounds rect is the viewport. In such scenarios, the `position` property of the rendered element is changed from `absolute` to `fixed`, which results in a constant, non-janky style property while the page scroll changes.

### Before:
![before](https://user-images.githubusercontent.com/1074748/37735536-9494d368-2d0b-11e8-875a-33357a2505b2.gif)

### After:
![after](https://user-images.githubusercontent.com/1074748/37735557-a20f8ef2-2d0b-11e8-8cf3-80d6bf537ea9.gif)
