### PR TITLE
Fixed miscalculation of position on Safari

### DIFF
--- a/packages/flowtip-react-dom/src/FlowTip.js
+++ b/packages/flowtip-react-dom/src/FlowTip.js
@@ -246,7 +246,7 @@ class FlowTip extends React.Component<Props, State> {
       return processBounds(nextProps.bounds);
     }
 
-    if (document.body && this._clippingBlockNode === document.documentElement) {
+    if (document.body) {
       return processBounds(
         new Rect(
           -window.scrollX,


### PR DESCRIPTION
On Safari, the flowtip appears far from the intended position (usually way to the top):

<img width="476" alt="before" src="https://user-images.githubusercontent.com/2574625/43791735-7c09e148-9a2b-11e8-994a-d669419632ec.png">

One way to fix this is to remove an extra condition. After the fix:

<img width="635" alt="after" src="https://user-images.githubusercontent.com/2574625/43791740-80280228-9a2b-11e8-8d68-3bdb86c0b9cf.png">


Please advise if this is the best way to fix the issue or if there is a better solution.